### PR TITLE
Enable Runtime Configuration for Local Plex Server Discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,7 @@ RUN pip install -e . --no-cache-dir
 
 COPY --from=build /app/dist frontend
 
+COPY entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+RUN chmod +x /docker-entrypoint.d/entrypoint.sh
+
 COPY unit-nginx-config.json /docker-entrypoint.d/config.json

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you'd prefer to self-host Plexio, you can do so easily using Docker. Follow t
 * *REDIS_URL*: URL for a Redis instance if you use `redis` cache (default: `redis://redis:6399/0`).
 * *PLEX_MATCHING_TOKEN*: Auth token for Plex media matching (default: `None`).
 * *SENTRY_DSN*: DSN for error tracking with Sentry (default: `None`).
+* *LOCAL_DISCOVERY*: Show local network Plex server addresses (default: `false`).
 
 ### Using addon with shared Plex server
 If you are using Plexio with a Plex server that you do not own (you will see a "shared" badge 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+cat <<EOF > /app/frontend/env-config.js
+window.env = {
+  VITE_LOCAL_DISCOVERY: "${LOCAL_DISCOVERY}"
+};
+EOF
+
+exec "$@"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/env-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,1 +1,21 @@
-declare const __APP_VERSION__: string
+/// <reference types="vite/client" />
+
+declare global {
+  const __APP_VERSION__: string;
+
+  interface ImportMetaEnv {
+    readonly VITE_LOCAL_DISCOVERY: string;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+
+  interface Window {
+    env: {
+      VITE_LOCAL_DISCOVERY: string;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
This pull request introduces dynamic runtime configuration support for local Plex server discovery. The changes include:

- **PlexService.tsx:** Updated to use a runtime environment variable (via `window.env.VITE_LOCAL_DISCOVERY`) with a default fallback value for controlling local server address filtering.
- **Dockerfile & entrypoint.sh:** Modified to generate an `env-config.js` file at container startup from Docker's `LOCAL_DISCOVERY` variable, enabling dynamic runtime configuration.
- **README:** Updated to document the `LOCAL_DISCOVERY` option and its default behavior.
These enhancements allow users to control the visibility of local Plex server addresses without the need for a rebuild.